### PR TITLE
Use CFPB-owned account for automated commits

### DIFF
--- a/.github/workflows/sbl-spec-json-to-csv.yml
+++ b/.github/workflows/sbl-spec-json-to-csv.yml
@@ -7,13 +7,8 @@ on:
       - fig-files/file-spec/2024-data-points.json
       - fig-files/file-spec/json_to_csv.py
 env:
-  # HACK: Actions doesn't provide a built-in means of referencing the github-actions
-  #       Git user. There is an open issue to remedy this, but others have found this
-  #       workaround in the meantime.
-  # SEE:  https://github.com/actions/checkout/issues/13
-  # SEE:  https://github.com/orgs/community/discussions/26560#discussioncomment-3252339
-  GIT_USERNAME: github-actions[bot]
-  GIT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+  GIT_USERNAME: CFPBadmin
+  GIT_EMAIL: CFPBadmin@users.noreply.github.com
   JSON_FILE_PATH: fig-files/file-spec/2024-data-points.json
   CSV_FILE_PATH: fig-files/file-spec/2024-data-points.csv
 jobs:


### PR DESCRIPTION
Use a CFPB-owned account for automated commits. Commits made by github actions will now use the [CFPBAdmin](https://github.com/CFPBadmin) account.